### PR TITLE
Use the persistent context to reduce the number of password prompts

### DIFF
--- a/google.go
+++ b/google.go
@@ -37,9 +37,7 @@ func (g *Google) Login() (string, error) {
 		return SAMLResponse, fmt.Errorf("unable to run playwright %v", err)
 	}
 
-	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
-		Headless: playwright.Bool(false),
-	})
+	browser, err := pw.Chromium.LaunchPersistentContext(string(*playwright.ColorSchemeDark), playwright.BrowserTypeLaunchPersistentContextOptions{Headless: playwright.Bool(false)})
 	if err != nil {
 		return SAMLResponse, fmt.Errorf("could not launch a browser %v", err)
 	}


### PR DESCRIPTION
The previous behavior was to log in using incognito mode on chromium.  As a result, the user has to specify their google credentials every time they get aws credentials.  This results in unnecessary password prompts -- instead, using the persistent context will allow the session to persist as long as the credentials in browser state are still valid.  